### PR TITLE
Resolves #29

### DIFF
--- a/src/GeoAPI/CoordinateSystems/WGS84ConversionInfo.cs
+++ b/src/GeoAPI/CoordinateSystems/WGS84ConversionInfo.cs
@@ -45,7 +45,7 @@ namespace GeoAPI.CoordinateSystems
 #if HAS_SYSTEM_SERIALIZABLEATTRIBUTE
     [Serializable]
 #endif
-    public class Wgs84ConversionInfo : IEquatable<Wgs84ConversionInfo>
+    public class Wgs84ConversionInfo
     {
         private const double SEC_TO_RAD = 4.84813681109535993589914102357e-6;
 

--- a/src/GeoAPI/Geometries/Coordinate.cs
+++ b/src/GeoAPI/Geometries/Coordinate.cs
@@ -27,7 +27,7 @@ namespace GeoAPI.Geometries
     [Serializable]
 #endif
 #pragma warning disable 612,618
-    public class Coordinate : ICoordinate, IComparable<Coordinate>, IEquatable<Coordinate>
+    public class Coordinate : ICoordinate, IComparable<Coordinate>
 #pragma warning restore 612,618
     {
         ///<summary>
@@ -484,17 +484,6 @@ namespace GeoAPI.Geometries
         bool ICoordinate.Equals2D(ICoordinate other)
         {
             return X == other.X && Y == other.Y;
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        [Obsolete]
-        Boolean IEquatable<ICoordinate>.Equals(ICoordinate other)
-        {
-            return ((ICoordinate)this).Equals2D(other);
         }
 
         /// <summary>

--- a/src/GeoAPI/Geometries/Envelope.cs
+++ b/src/GeoAPI/Geometries/Envelope.cs
@@ -23,7 +23,7 @@ namespace GeoAPI.Geometries
     [Serializable]
 #endif
 #pragma warning disable 612,618
-    public class Envelope : IEnvelope, IEquatable<Envelope>, IComparable<Envelope>, IIntersectable<Envelope>, IExpandable<Envelope>
+    public class Envelope : IEnvelope, IComparable<Envelope>, IIntersectable<Envelope>, IExpandable<Envelope>
 #pragma warning restore 612,618
     {
         /// <summary>
@@ -1236,15 +1236,6 @@ namespace GeoAPI.Geometries
                 return dx;
 
             return Math.Sqrt(dx * dx + dy * dy);
-        }
-
-        bool IEquatable<IEnvelope>.Equals(IEnvelope other)
-        {
-            if (IsNull)
-                return other.IsNull;
-
-            return _maxx == other.MaxX && _maxy == other.MaxY &&
-                   _minx == other.MinX && _miny == other.MinY;
         }
 
         int IComparable<IEnvelope>.CompareTo(IEnvelope other)

--- a/src/GeoAPI/Geometries/ICoordinate.cs
+++ b/src/GeoAPI/Geometries/ICoordinate.cs
@@ -14,7 +14,7 @@ namespace GeoAPI.Geometries
     [Obsolete("Use Coordinate class instead")]
     public interface ICoordinate : 
         ICloneable,
-        IComparable, IComparable<ICoordinate>, IEquatable<ICoordinate>
+        IComparable, IComparable<ICoordinate>
     {
         /// <summary>
         /// The x-ordinate value

--- a/src/GeoAPI/Geometries/IEnvelope.cs
+++ b/src/GeoAPI/Geometries/IEnvelope.cs
@@ -28,7 +28,7 @@ namespace GeoAPI.Geometries
     [Obsolete("Use Envelope class instead")]
     public interface IEnvelope : 
         ICloneable,
-        IComparable, IComparable<IEnvelope>, IEquatable<IEnvelope>
+        IComparable, IComparable<IEnvelope>
     {
         /// <summary>
         /// Gets the area of the envelope

--- a/src/GeoAPI/Geometries/IGeometry.cs
+++ b/src/GeoAPI/Geometries/IGeometry.cs
@@ -12,7 +12,7 @@ namespace GeoAPI.Geometries
     /// <summary>  
     /// Interface for basic implementation of <c>Geometry</c>.
     /// </summary>
-    public interface IGeometry : ICloneable, IComparable, IComparable<IGeometry>, IEquatable<IGeometry>
+    public interface IGeometry : ICloneable, IComparable, IComparable<IGeometry>
     {
         ///<summary>
         /// The <see cref="IGeometryFactory"/> used to create this geometry
@@ -189,6 +189,9 @@ namespace GeoAPI.Geometries
         IGeometry Union(IGeometry other);
 
         IGeometry Union();
+
+        [Obsolete("Favor either EqualsTopologically or EqualsExact instead.")]
+        bool Equals(IGeometry other);
 
         /// <summary>
         /// Tests whether this geometry is topologically equal to the argument geometry

--- a/src/GeoAPI/Geometries/IPrecisionModel.cs
+++ b/src/GeoAPI/Geometries/IPrecisionModel.cs
@@ -32,7 +32,7 @@ namespace GeoAPI.Geometries
     /// Interface for classes specifying the precision model of the <c>Coordinate</c>s in a <c>IGeometry</c>.
     /// In other words, specifies the grid of allowable points for all <c>IGeometry</c>s.
     /// </summary>
-    public interface IPrecisionModel : IComparable, IComparable<IPrecisionModel>, IEquatable<IPrecisionModel>
+    public interface IPrecisionModel : IComparable, IComparable<IPrecisionModel>
     {
         /// <summary>
         /// Gets a value indicating the <see cref="PrecisionModels">precision model</see> type


### PR DESCRIPTION
Just removes `IEquatable<T>` from everything except `Interval`.
Also adds `bool Equals(IGeometry g)` to `GeoAPI.IGeometry`, marked obsolete, for parity with JTS.