### PR TITLE
Bring back assembly signing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,14 @@
 language: csharp
 sudo: required  
 dist: trusty  
-dotnet: 1.0.1
 addons:  
   apt:
     packages:
-    - referenceassemblies-pcl
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
-    - libunwind8
-    - zlib1g
+      - referenceassemblies-pcl
 mono:  
-  - 4.2.3
-os:  
-  - linux
-osx_image: xcode7.1  
+  - latest
+solution: NetTopologySuite.sln
 install:  
-  - nuget restore GeoAPI.sln
   - nuget install NUnit.Runners -version 3.6.0 -OutputDirectory .testRunner
 script:
   - ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -3,5 +3,10 @@
 #exit if any command fails
 set -e
 
+# Build the project
+#
 msbuild GeoAPI.sln "/t:Restore;Build" /p:Configuration=Release "/p:FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/" /v:minimal /p:WarningLevel=3
+
+# Run unit tests
+#
 mono .testRunner/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe ./test/GeoAPI.Tests/bin/Release/net45/GeoAPI.Tests.dll

--- a/build.sh
+++ b/build.sh
@@ -3,16 +3,5 @@
 #exit if any command fails
 set -e
 
-dotnet --version
-dotnet restore
-dotnet build ./src/GeoAPI -f netstandard1.0
-
-# TODO: replace this with the Mono 5.0 mbuild.
-#
-# Build the project
-#
-# xbuild /p:Configuration=Release /t:"Build" GeoAPI.sln /v:minimal
-#
-# Run unit tests
-#
-# mono .testRunner/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe ./Release/v4.5/AnyCPU/GeoAPI.Tests.dll 
+msbuild GeoAPI.sln "/t:Restore;Build" /p:Configuration=Release "/p:FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/" /v:minimal /p:WarningLevel=3
+mono ./testrunner/NUnit.Runners.3.6.0/tools/nunit-console.exe ./test/GeoAPI.Tests/bin/Release/net45/GeoAPI.Tests.dll

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@
 set -e
 
 msbuild GeoAPI.sln "/t:Restore;Build" /p:Configuration=Release "/p:FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/" /v:minimal /p:WarningLevel=3
-mono ./testrunner/NUnit.Runners.3.6.0/tools/nunit-console.exe ./test/GeoAPI.Tests/bin/Release/net45/GeoAPI.Tests.dll
+mono .testRunner/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe ./test/GeoAPI.Tests/bin/Release/net45/GeoAPI.Tests.dll

--- a/src/GeoAPI/GeoAPI.csproj
+++ b/src/GeoAPI/GeoAPI.csproj
@@ -106,9 +106,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 
-    <SignAssembly>false</SignAssembly>
-    <AssemblyOriginatorKeyFile></AssemblyOriginatorKeyFile>
-
     <DefineConstants>$(DefineConstants);FEATURE_DEFAULT_PARAMETERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_INTERFACE_VARIANCE</DefineConstants>
     <DefineConstants>$(DefineConstants);HAS_SYSTEM_DOUBLE_TRYPARSE</DefineConstants>

--- a/test/GeoAPI.Tests/GeoAPI.Tests.csproj
+++ b/test/GeoAPI.Tests/GeoAPI.Tests.csproj
@@ -4,8 +4,6 @@
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
     <TargetFramework>net45</TargetFramework>
     <NoWarn>1591</NoWarn>
-    <OutputPath>$(SolutionDir)$(Configuration)\$(Platform)</OutputPath>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 


### PR DESCRIPTION
This resolves the issue from #27 a different way.

Despite #27's claims, assembly signing actually does appear to be (semi-?) supported on .NET Core, and @bastien-hofmann mentioned [over here](https://github.com/NetTopologySuite/GeoAPI/issues/27#issuecomment-337852122) that conditionally signing the assembly makes things a lot worse.  I'm not exactly sure why this Travis-CI configuration is throwing an error at us when I **just** do the GeoAPI.csproj change, but when I make the GeoAPI configuration look more like the NTS configuration, Travis-CI stops throwing that error.

Also making GeoAPI.Tests stop building to the main release area, since that's just silly.

Also, might as well run the unit tests again... it's not like they're slow.